### PR TITLE
Use build profile to enable RTEMS cross build

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+epics-stream (2.7.7-2) unstable; urgency=medium
+
+  * BLD: pkg headers
+  * BLD: appease lintian
+
+ -- Daron Chabot <chabot@frib.msu.edu>  Mon, 02 Apr 2018 11:35:34 -0400
+
 epics-stream (2.7.7-1) unstable; urgency=medium
 
   * New upstream version 2.7.7

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+epics-stream (2.7.7-3) unstable; urgency=medium
+
+  * Use build profile to enable RTEMS cross build
+
+ -- Martin Konrad <konrad@frib.msu.edu>  Thu, 13 Sep 2018 14:46:50 -0400
+
 epics-stream (2.7.7-2) unstable; urgency=medium
 
   * BLD: pkg headers

--- a/debian/control
+++ b/debian/control
@@ -37,7 +37,7 @@ Depends: libstream2.7.7 (= ${binary:Version}),
          ${epics:Depends},
 Conflicts: epics-synapps, epics-synapps-dev,
 Description: streamdevice header files
- Streamdevice header files.
+ Streamdevice header files including core api.
  .
  This package contains headers for development with libstream.
 

--- a/debian/control
+++ b/debian/control
@@ -2,17 +2,17 @@ Source: epics-stream
 Section: libdevel
 Priority: extra
 Maintainer: Martin Konrad <konrad@frib.msu.edu>
-Build-Depends: debhelper (>= 9), epics-debhelper (>= 8.14~),
-               libpcre3-dev,
+Build-Depends: debhelper (>= 9.20141010), dpkg-dev (>= 1.17.14),
+               epics-debhelper (>= 8.14~), libpcre3-dev,
                epics-dev, epics-calc-dev, epics-asyn-dev,
-               rtems-asyn-mvme2100,
-               rtems-asyn-mvme3100,
-               rtems-asyn-mvme5500,
-               rtems-asyn-pc386,
-               rtems-calc-mvme2100,
-               rtems-calc-mvme3100,
-               rtems-calc-mvme5500,
-               rtems-calc-pc386,
+               rtems-asyn-mvme2100 <pkg.epics-base.rtems>,
+               rtems-asyn-mvme3100 <pkg.epics-base.rtems>,
+               rtems-asyn-mvme5500 <pkg.epics-base.rtems>,
+               rtems-asyn-pc386 <pkg.epics-base.rtems>,
+               rtems-calc-mvme2100 <pkg.epics-base.rtems>,
+               rtems-calc-mvme3100 <pkg.epics-base.rtems>,
+               rtems-calc-mvme5500 <pkg.epics-base.rtems>,
+               rtems-calc-pc386 <pkg.epics-base.rtems>,
 XS-Rtems-Build-Depends: rtems-epics, rtems-seq, rtems-sscan, rtems-calc, rtems-asyn,
 Standards-Version: 3.9.6
 Homepage: http://epics.web.psi.ch/software/streamdevice/
@@ -50,6 +50,7 @@ Description: 'expect' for EPICS
  This package contains runtime libraries
 
 Package: rtems-stream-mvme2100
+Build-Profiles: <pkg.epics-base.rtems>
 Architecture: all
 Depends: epics-stream-dev (>= ${source:Version}),
          epics-stream-dev (<< ${source:Version}.1~),
@@ -61,6 +62,7 @@ Description: 'expect' for EPICS
  This package contains support for the MVME2100 VME SBC
 
 Package: rtems-stream-mvme3100
+Build-Profiles: <pkg.epics-base.rtems>
 Architecture: all
 Depends: epics-stream-dev (>= ${source:Version}),
          epics-stream-dev (<< ${source:Version}.1~),
@@ -72,6 +74,7 @@ Description: 'expect' for EPICS
  This package contains support for the MVME3100 VME SBC
 
 Package: rtems-stream-mvme5500
+Build-Profiles: <pkg.epics-base.rtems>
 Architecture: all
 Depends: epics-stream-dev (>= ${source:Version}),
          epics-stream-dev (<< ${source:Version}.1~),
@@ -83,6 +86,7 @@ Description: 'expect' for EPICS
  This package contains support for the MVME5500 VME SBC
 
 Package: rtems-stream-pc386
+Build-Profiles: <pkg.epics-base.rtems>
 Architecture: all
 Depends: epics-stream-dev (>= ${source:Version}),
          epics-stream-dev (<< ${source:Version}.1~),

--- a/debian/control
+++ b/debian/control
@@ -30,6 +30,17 @@ Description: 'expect' for EPICS
  .
  This package contains headers and libraries needed at build time.
 
+Package: libstream-headers
+Architecture: any
+Depends: libstream2.7.7 (= ${binary:Version}),
+         ${shlibs:Depends}, ${misc:Depends},
+         ${epics:Depends},
+Conflicts: epics-synapps, epics-synapps-dev,
+Description: streamdevice header files
+ Streamdevice header files.
+ .
+ This package contains headers for development with libstream.
+
 Package: libstream2.7.7
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends},

--- a/debian/libstream-headers.install
+++ b/debian/libstream-headers.install
@@ -1,0 +1,7 @@
+src/StreamBuffer.h usr/lib/epics/include
+src/StreamBusInterface.h usr/lib/epics/include
+src/StreamCore.h usr/lib/epics/include
+src/StreamError.h usr/lib/epics/include
+src/StreamFormatConverter.h usr/lib/epics/include
+src/StreamFormat.h usr/lib/epics/include
+src/StreamProtocol.h usr/lib/epics/include

--- a/debian/source/lintian-overrides
+++ b/debian/source/lintian-overrides
@@ -1,0 +1,12 @@
+epics-stream source: invalid-restriction-formula-in-build-profiles-field <pkg.epics-base.rtems> rtems-stream-mvme2100
+epics-stream source: invalid-restriction-formula-in-build-profiles-field <pkg.epics-base.rtems> rtems-stream-mvme3100
+epics-stream source: invalid-restriction-formula-in-build-profiles-field <pkg.epics-base.rtems> rtems-stream-mvme5500
+epics-stream source: invalid-restriction-formula-in-build-profiles-field <pkg.epics-base.rtems> rtems-stream-pc386
+epics-stream source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-asyn-mvme2100 <pkg.epics-base.rtems>]
+epics-stream source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-asyn-mvme3100 <pkg.epics-base.rtems>]
+epics-stream source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-asyn-mvme5500 <pkg.epics-base.rtems>]
+epics-stream source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-asyn-pc386 <pkg.epics-base.rtems>]
+epics-stream source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-calc-mvme2100 <pkg.epics-base.rtems>]
+epics-stream source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-calc-mvme3100 <pkg.epics-base.rtems>]
+epics-stream source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-calc-mvme5500 <pkg.epics-base.rtems>]
+epics-stream source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-calc-pc386 <pkg.epics-base.rtems>]


### PR DESCRIPTION
This allows facilities that do not use RTEMS to get rid of the complexity of building this package's RTEMS dependencies. Set the environment variable `DEB_BUILD_PROFILES=pkg.epics-stream.rtems` when compiling to enable the RTEMS build.