### PR TITLE
Package headers

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+epics-stream (2.7.7-2) unstable; urgency=medium
+
+  * BLD: pkg headers
+  * BLD: appease lintian
+
+ -- Daron Chabot <chabot@frib.msu.edu>  Mon, 02 Apr 2018 11:35:34 -0400
+
 epics-stream (2.7.7-1) unstable; urgency=medium
 
   * New upstream version 2.7.7

--- a/debian/control
+++ b/debian/control
@@ -37,7 +37,7 @@ Depends: libstream2.7.7 (= ${binary:Version}),
          ${epics:Depends},
 Conflicts: epics-synapps, epics-synapps-dev,
 Description: streamdevice header files
- Streamdevice header files.
+ Streamdevice header files including core api.
  .
  This package contains headers for development with libstream.
 

--- a/debian/control
+++ b/debian/control
@@ -30,6 +30,17 @@ Description: 'expect' for EPICS
  .
  This package contains headers and libraries needed at build time.
 
+Package: libstream-headers
+Architecture: any
+Depends: libstream2.7.7 (= ${binary:Version}),
+         ${shlibs:Depends}, ${misc:Depends},
+         ${epics:Depends},
+Conflicts: epics-synapps, epics-synapps-dev,
+Description: streamdevice header files
+ Streamdevice header files.
+ .
+ This package contains headers for development with libstream.
+
 Package: libstream2.7.7
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends},

--- a/debian/libstream-headers.install
+++ b/debian/libstream-headers.install
@@ -1,0 +1,7 @@
+src/StreamBuffer.h usr/lib/epics/include
+src/StreamBusInterface.h usr/lib/epics/include
+src/StreamCore.h usr/lib/epics/include
+src/StreamError.h usr/lib/epics/include
+src/StreamFormatConverter.h usr/lib/epics/include
+src/StreamFormat.h usr/lib/epics/include
+src/StreamProtocol.h usr/lib/epics/include


### PR DESCRIPTION
In some rare cases access to the StreamDevice header files is required (e.g. when developing custom format converters).